### PR TITLE
Add a bogus entry to Northside Maintainers

### DIFF
--- a/northside/MAINTAINERS
+++ b/northside/MAINTAINERS
@@ -1,0 +1,2 @@
+Doogie Houser
+r


### PR DESCRIPTION
Add a fictional character in order to introduce a merge conflict.